### PR TITLE
Refine responsiveness and restore image paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,11 +56,14 @@
     }
     </script>
     
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <meta name="theme-color" content="#000000" />
     
     <!-- Favicon -->
     <link rel="icon" type="image/jpeg" href="/assets/website_logo.jpg" />
+    <link rel="preload" as="image" href="/assets/portfolio_image.png" />
     
     <!-- Skip Navigation -->
     <style>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -165,7 +165,7 @@ export const Hero = memo(function Hero() {
               <img
                 src="/assets/portfolio_image.png"
                 alt="Daryl Gatt"
-                className="w-[300px] sm:w-[400px] h-[300px] sm:h-[400px] object-cover"
+                className="w-full max-w-xs sm:max-w-sm md:max-w-md aspect-square object-cover"
                 loading="lazy"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -109,7 +109,7 @@ export function ParticleBackground() {
   return (
     <canvas
       ref={canvasRef}
-      className="fixed inset-0 pointer-events-none z-0"
+      className="fixed inset-0 pointer-events-none z-0 transform-gpu"
       style={{
         background: 'black',
         opacity: 0.5,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,13 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
+    container: {
+      center: true,
+      padding: '1rem',
+      screens: {
+        '2xl': '1280px',
+      },
+    },
     extend: {
       fontFamily: {
         mono: ['JetBrains Mono', 'monospace'],


### PR DESCRIPTION
## Summary
- center Tailwind container for consistent layouts
- preload fonts and adjust viewport for mobile
- keep hero image responsive but serve PNG to avoid extension issues
- enable GPU acceleration on the particle background canvas
- revert Open Graph and favicon paths back to JPG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852e63860fc8322a1cfa0b28436a3f0