### PR TITLE
Add aria-hidden attributes to decorative icons

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -12,7 +12,7 @@ export function AboutSection() {
         className="container mx-auto px-4"
       >
         <h2 className="text-4xl md:text-5xl font-light mb-12 flex items-center gap-4">
-          <Terminal className="w-8 h-8 text-green-500" />
+          <Terminal className="w-8 h-8 text-green-500" aria-hidden="true" />
           <span>whoami</span>
         </h2>
         

--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -57,8 +57,9 @@ export function BackToTopButton() {
           }`}
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
+          aria-label="Back to top"
         >
-          <ArrowUp className="w-6 h-6" />
+          <ArrowUp className="w-6 h-6" aria-hidden="true" />
         </motion.button>
       )}
     </AnimatePresence>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -224,7 +224,7 @@ export function ContactSection() {
         className="container mx-auto px-4"
       >
         <h2 className="section-header text-4xl md:text-5xl font-light mb-12 flex items-center gap-4">
-          <Send className="w-8 h-8 text-green-500" />
+          <Send className="w-8 h-8 text-green-500" aria-hidden="true" />
           <span>contact</span>
         </h2>
 
@@ -342,7 +342,7 @@ export function ContactSection() {
           >
             <div className="flex items-center justify-between mb-6">
               <div className="flex items-center gap-2 text-green-500">
-                <Key className="w-4 h-4" />
+                <Key className="w-4 h-4" aria-hidden="true" />
                 <span>PGP Public Key</span>
               </div>
               <button 
@@ -351,12 +351,12 @@ export function ContactSection() {
               >
                 {copied ? (
                   <>
-                    <Check className="w-4 h-4" />
+                    <Check className="w-4 h-4" aria-hidden="true" />
                     <span>Copied!</span>
                   </>
                 ) : (
                   <>
-                    <Copy className="w-4 h-4" />
+                    <Copy className="w-4 h-4" aria-hidden="true" />
                     <span>Copy Key</span>
                   </>
                 )}

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -59,14 +59,14 @@ export function CustomCursor() {
       }}
     >
       {cursorType === 'default' && (
-        <Circle className="w-4 h-4 text-cyan-400" strokeWidth={1.5} />
+        <Circle className="w-4 h-4 text-cyan-400" strokeWidth={1.5} aria-hidden="true" />
       )}
       {cursorType === 'pointer' && (
-        <Pointer className="w-5 h-5 text-amber-400" strokeWidth={1.5} />
+        <Pointer className="w-5 h-5 text-amber-400" strokeWidth={1.5} aria-hidden="true" />
       )}
       {cursorType === 'text' && (
         <div className="relative">
-          <Type className="w-5 h-5 text-green-400" strokeWidth={1.5} />
+          <Type className="w-5 h-5 text-green-400" strokeWidth={1.5} aria-hidden="true" />
           {isTyping && (
             <div className="absolute -right-12 top-1/2 -translate-y-1/2">
               <div className="flex gap-2">

--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -99,7 +99,7 @@ export function ExperienceSection() {
         className="container mx-auto px-4"
       >
         <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-light mb-8 sm:mb-12 flex items-center gap-2 sm:gap-4">
-          <History className="w-6 h-6 sm:w-8 sm:h-8 text-green-500 flex-shrink-0" />
+          <History className="w-6 h-6 sm:w-8 sm:h-8 text-green-500 flex-shrink-0" aria-hidden="true" />
           <span className="truncate">cat ~/exp.log</span>
         </h2>
 
@@ -135,11 +135,11 @@ export function ExperienceSection() {
                   <div className="flex flex-col h-full">
                     <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-4 gap-2">
                       <div className="flex items-center gap-2 text-green-400 text-xs sm:text-sm">
-                        <Calendar className="w-3 h-3 sm:w-4 sm:h-4" />
+                        <Calendar className="w-3 h-3 sm:w-4 sm:h-4" aria-hidden="true" />
                         <span>{experiences[currentIndex].period}</span>
                       </div>
                       <div className="flex items-center gap-2 text-gray-400 text-xs sm:text-sm">
-                        <Building2 className="w-3 h-3 sm:w-4 sm:h-4" />
+                        <Building2 className="w-3 h-3 sm:w-4 sm:h-4" aria-hidden="true" />
                         <span>{experiences[currentIndex].company}</span>
                       </div>
                     </div>
@@ -192,8 +192,9 @@ export function ExperienceSection() {
               whileTap={{ scale: 0.9 }}
               onClick={() => paginate(-1)}
               className="p-1.5 sm:p-2 rounded-full bg-green-500/10 border border-green-500/20 text-green-400 hover:bg-green-500/20 transition-colors"
+              aria-label="Previous experience"
             >
-              <ChevronLeft className="w-4 h-4 sm:w-6 sm:h-6" />
+              <ChevronLeft className="w-4 h-4 sm:w-6 sm:h-6" aria-hidden="true" />
             </motion.button>
 
             <div className="flex items-center gap-1.5 sm:gap-2">
@@ -216,8 +217,9 @@ export function ExperienceSection() {
               whileTap={{ scale: 0.9 }}
               onClick={() => paginate(1)}
               className="p-1.5 sm:p-2 rounded-full bg-green-500/10 border border-green-500/20 text-green-400 hover:bg-green-500/20 transition-colors"
+              aria-label="Next experience"
             >
-              <ChevronRight className="w-4 h-4 sm:w-6 sm:h-6" />
+              <ChevronRight className="w-4 h-4 sm:w-6 sm:h-6" aria-hidden="true" />
             </motion.button>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,19 +58,19 @@ export function Footer() {
               <a href="https://github.com/phantom0004" target="_blank" rel="noopener noreferrer" 
                  className="footer-link hover:text-green-400 transition-colors flex items-center gap-2 group text-sm sm:text-base"
                  aria-label="Visit my GitHub profile">
-                <Github className="w-3 h-3 sm:w-4 sm:h-4 group-hover:rotate-12 transition-transform duration-300" />
+                <Github className="w-3 h-3 sm:w-4 sm:h-4 group-hover:rotate-12 transition-transform duration-300" aria-hidden="true" />
                 <span>GitHub</span>
               </a>
               <a href="mailto:phantom.techsec@gmail.com" 
                  className="footer-link hover:text-green-400 transition-colors flex items-center gap-2 group text-sm sm:text-base"
                  aria-label="Send me an email">
-                <ExternalLink className="w-3 h-3 sm:w-4 sm:h-4 group-hover:rotate-12 transition-transform duration-300" />
+                <ExternalLink className="w-3 h-3 sm:w-4 sm:h-4 group-hover:rotate-12 transition-transform duration-300" aria-hidden="true" />
                 <span>Email</span>
               </a>
               <a href="https://mt.linkedin.com/in/daryl-gatt-web3" target="_blank" rel="noopener noreferrer" 
                  className="footer-link hover:text-green-400 transition-colors flex items-center gap-2 group text-sm sm:text-base"
                  aria-label="Connect with me on LinkedIn">
-                <ExternalLink className="w-3 h-3 sm:w-4 sm:h-4 group-hover:rotate-12 transition-transform duration-300" />
+                <ExternalLink className="w-3 h-3 sm:w-4 sm:h-4 group-hover:rotate-12 transition-transform duration-300" aria-hidden="true" />
                 <span>LinkedIn</span>
               </a>
             </div>
@@ -78,11 +78,11 @@ export function Footer() {
 
           <div className="space-y-2 sm:space-y-3 lg:text-right">
             <div className="flex items-center gap-2 text-green-500 lg:justify-end">
-              <Terminal className="w-4 h-4 sm:w-5 sm:h-5" />
+              <Terminal className="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
               <span className="font-mono text-xs sm:text-sm">v1.0</span>
             </div>
             <p className="text-xs sm:text-sm leading-relaxed flex items-center gap-2 lg:justify-end">
-              Built with <Heart className="w-3 h-3 sm:w-4 sm:h-4 text-red-500 animate-pulse" /> using React
+              Built with <Heart className="w-3 h-3 sm:w-4 sm:h-4 text-red-500 animate-pulse" aria-hidden="true" /> using React
             </p>
             <p className="text-[10px] sm:text-xs opacity-60">
               © {currentYear} Daryl Gatt

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -120,7 +120,7 @@ export const Hero = memo(function Hero() {
                 whileTap={{ scale: 0.98 }}
                 aria-label="View portfolio in terminal mode"
               >
-                <Terminal className="w-4 h-4 sm:w-5 sm:h-5" />
+                <Terminal className="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
                 <span>View Portfolio as Terminal</span>
               </motion.button>
 
@@ -131,7 +131,7 @@ export const Hero = memo(function Hero() {
                 whileTap={{ scale: 0.98 }}
                 aria-label="Download my CV"
               >
-                <FileDown className="w-4 h-4 sm:w-5 sm:h-5" />
+                <FileDown className="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
                 <span>Download CV</span>
               </motion.button>
 
@@ -143,7 +143,7 @@ export const Hero = memo(function Hero() {
                 aria-label="Scroll to about section"
               >
                 <span>Learn more about me</span>
-                <ChevronDown className="w-4 h-4 sm:w-5 sm:h-5 group-hover:animate-bounce" />
+                <ChevronDown className="w-4 h-4 sm:w-5 sm:h-5 group-hover:animate-bounce" aria-hidden="true" />
               </motion.a>
             </div>
           </motion.div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -124,7 +124,7 @@ export const Navigation = memo(function Navigation() {
                   whileTap={{ scale: 0.95 }}
                   aria-label={item.label}
                 >
-                  <Icon className="w-4 h-4 group-hover:rotate-12 transition-transform duration-300" />
+                  <Icon className="w-4 h-4 group-hover:rotate-12 transition-transform duration-300" aria-hidden="true" />
                   <span className="hidden sm:inline">{item.name}.sh</span>
                 </motion.button>
               );
@@ -148,7 +148,7 @@ export const Navigation = memo(function Navigation() {
                   exit={{ rotate: 0, opacity: 0 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <X className="w-8 h-8" />
+                  <X className="w-8 h-8" aria-hidden="true" />
                 </motion.div>
               ) : (
                 <motion.div
@@ -158,7 +158,7 @@ export const Navigation = memo(function Navigation() {
                   exit={{ rotate: 180, opacity: 0 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <Menu className="w-8 h-8" />
+                  <Menu className="w-8 h-8" aria-hidden="true" />
                 </motion.div>
               )}
             </AnimatePresence>
@@ -202,7 +202,7 @@ export const Navigation = memo(function Navigation() {
                 whileTap={{ scale: 0.95 }}
                 aria-label={item.label}
               >
-                <Icon className="w-5 h-5 group-hover:rotate-12 transition-transform duration-300" />
+                <Icon className="w-5 h-5 group-hover:rotate-12 transition-transform duration-300" aria-hidden="true" />
                 <span className="relative leading-none">
                   {item.name}.sh
                   <motion.span

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -119,7 +119,7 @@ export function NotFound() {
               whileTap={{ scale: 0.98 }}
               aria-label="Return to home page"
             >
-              <ArrowLeft className="w-4 h-4 transition-transform group-hover:-translate-x-1" />
+              <ArrowLeft className="w-4 h-4 transition-transform group-hover:-translate-x-1" aria-hidden="true" />
               <span>Return Home</span>
             </motion.button>
           </div>

--- a/src/components/PortfoliosSection.tsx
+++ b/src/components/PortfoliosSection.tsx
@@ -35,7 +35,7 @@ export function PortfoliosSection() {
         className="container mx-auto px-4"
       >
         <h2 className="text-4xl md:text-5xl font-light mb-12 flex items-center gap-4">
-          <Link className="w-8 h-8 text-green-500" />
+          <Link className="w-8 h-8 text-green-500" aria-hidden="true" />
           <span>cat ~/profiles</span>
         </h2>
 
@@ -62,7 +62,7 @@ export function PortfoliosSection() {
                   {portfolio.description}
                 </p>
                 <div className="absolute bottom-3 right-3 text-green-500/50 group-hover:text-green-500 transition-colors">
-                  <Link className="w-5 h-5" />
+                  <Link className="w-5 h-5" aria-hidden="true" />
                 </div>
               </div>
             </motion.a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -115,7 +115,7 @@ function ProjectCard({ project }: { project: typeof projects[0] }) {
                 animate={{ rotate: 360 }}
                 transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
               >
-                <Star className="w-5 h-5 text-amber-500 fill-amber-500/50" />
+                <Star className="w-5 h-5 text-amber-500 fill-amber-500/50" aria-hidden="true" />
               </motion.div>
             )}
           </h3>
@@ -151,7 +151,7 @@ function ProjectCard({ project }: { project: typeof projects[0] }) {
               isFeatured ? 'hover:text-amber-500' : 'hover:text-green-500'
             } transition-colors`}
           >
-            <Github className="w-4 h-4" />
+            <Github className="w-4 h-4" aria-hidden="true" />
             <span>Source</span>
           </a>
           {project.demo && (
@@ -163,7 +163,7 @@ function ProjectCard({ project }: { project: typeof projects[0] }) {
                 isFeatured ? 'hover:text-amber-500' : 'hover:text-green-500'
               } transition-colors`}
             >
-              <ExternalLink className="w-4 h-4" />
+              <ExternalLink className="w-4 h-4" aria-hidden="true" />
               <span>Demo</span>
             </a>
           )}
@@ -184,7 +184,7 @@ export function ProjectsSection() {
         className="container mx-auto px-4"
       >
         <h2 className="text-4xl md:text-5xl font-light mb-12 flex items-center gap-4">
-          <Code2 className="w-8 h-8 text-green-500" />
+          <Code2 className="w-8 h-8 text-green-500" aria-hidden="true" />
           <span>ls ~/projects</span>
         </h2>
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -592,7 +592,7 @@ export function Terminal() {
               onClick={() => navigate('/')}
               className="group w-3 h-3 sm:w-4 sm:h-4 flex items-center justify-center rounded-full bg-red-500/50 hover:bg-red-500"
             >
-              <X className="w-2 h-2 text-black opacity-75 group-hover:opacity-100 transition-opacity" />
+              <X className="w-2 h-2 text-black opacity-75 group-hover:opacity-100 transition-opacity" aria-hidden="true" />
             </button>
             <div className="w-3 h-3 sm:w-4 sm:h-4 rounded-full bg-yellow-500/50" />
             <button
@@ -601,9 +601,9 @@ export function Terminal() {
               className="group w-3 h-3 sm:w-4 sm:h-4 flex items-center justify-center rounded-full bg-green-500/50 hover:bg-green-500"
             >
               {isMaximized ? (
-                <Minimize2 className="w-2 h-2 text-black opacity-75 group-hover:opacity-100 transition-opacity" />
+                <Minimize2 className="w-2 h-2 text-black opacity-75 group-hover:opacity-100 transition-opacity" aria-hidden="true" />
               ) : (
-                <Maximize2 className="w-2 h-2 text-black opacity-75 group-hover:opacity-100 transition-opacity" />
+                <Maximize2 className="w-2 h-2 text-black opacity-75 group-hover:opacity-100 transition-opacity" aria-hidden="true" />
               )}
             </button>
           </div>
@@ -681,8 +681,9 @@ export function Terminal() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-gray-500 hover:text-green-400 transition-colors"
+                    aria-label={link.name}
                   >
-                    <Icon className="w-3 h-3 sm:w-4 sm:h-4" />
+                    <Icon className="w-3 h-3 sm:w-4 sm:h-4" aria-hidden="true" />
                   </a>
                 );
               })}


### PR DESCRIPTION
## Summary
- mark icons with `aria-hidden` when they don't provide additional meaning
- keep accessible labels on buttons and links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f82305d08322b3473f88079c52bc