### PR TITLE
Use env vars for analytics and forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,19 @@ npm install
 ```bash
 npm start
 ```
- 
+
 This command will start the development server. Open your browser and navigate to http://localhost:3000 to view the website.
+
+### Environment Variables
+
+Create a `.env` file in the project root with the following variables:
+
+```bash
+VITE_GA_ID=your-google-analytics-id
+VITE_FORMSPREE_URL=https://formspree.io/f/your-form-id
+```
+
+These values are required for analytics tracking and for submitting the contact form.
 
 --- 
 

--- a/index.html
+++ b/index.html
@@ -26,13 +26,13 @@
     <meta name="twitter:image" content="https://darylgatt.dev/assets/website_logo.jpg" />
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-80YS4JJGFM"></script>
-    <script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_ID%"></script>
+    <script type="module">
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-80YS4JJGFM');
+      gtag('config', import.meta.env.VITE_GA_ID);
     </script>
 
     <!-- Structured Data -->

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -185,7 +185,7 @@ export function ContactSection() {
         message,
       };
 
-      const response = await fetch('https://formspree.io/f/mqaplvwo', {
+      const response = await fetch(import.meta.env.VITE_FORMSPREE_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- use `VITE_GA_ID` from `import.meta.env` in index.html
- read `VITE_FORMSPREE_URL` from `import.meta.env`
- document required env vars in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852f820dd7c8322ab407e6dacbe5d77