### PR TITLE
feat: add MeDirect experience

### DIFF
--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -4,10 +4,24 @@ import { Calendar, Building2, ChevronLeft, ChevronRight, History } from 'lucide-
 
 const experiences = [
   {
+    title: "Junior Internal Red Team Security Engineer",
+    company: "MeDirect",
+    period: "Jul 2025 – Present",
+    description:
+      "Conduct simulated cyber attacks to assess and strengthen the bank's security posture under senior guidance.",
+    achievements: [
+      "Executed red team exercises to uncover security gaps",
+      "Collaborated with senior engineers to harden systems",
+      "Documented findings to drive remediation efforts"
+    ],
+    technologies: ["Red Teaming", "Security Testing", "Banking"]
+  },
+  {
     title: "Junior Software Developer & Cybersecurity Sales Assistant",
     company: "SG Solutions",
-    period: "Jan 2025 – Present",
-    description: "Supported cybersecurity product sales (e.g., BullWall), managed document systems (e.g., DocuWare), and contributed to client solution delivery.",
+    period: "Jan 2025 – Jul 2025",
+    description:
+      "Supported cybersecurity product sales (e.g., BullWall), managed document systems (e.g., DocuWare), and contributed to client solution delivery.",
     achievements: [
       "Assisted in implementing cybersecurity solutions for clients",
       "Completed the DTE course and applied it in documentation processes",
@@ -131,7 +145,13 @@ export function ExperienceSection() {
                 }}
                 className="absolute w-full h-full"
               >
-                <div className="h-full bg-[rgba(var(--bg-rgb),0.4)] rounded-xl p-4 sm:p-6 md:p-8 border border-green-500/20 backdrop-blur-sm overflow-y-auto">
+                <div
+                  className={`h-full bg-[rgba(var(--bg-rgb),0.4)] rounded-xl p-4 sm:p-6 md:p-8 border ${
+                    currentIndex === 0
+                      ? 'border-yellow-500 shadow-lg shadow-yellow-500/50'
+                      : 'border-green-500/20'
+                  } backdrop-blur-sm overflow-y-auto`}
+                >
                   <div className="flex flex-col h-full">
                     <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-4 gap-2">
                       <div className="flex items-center gap-2 text-green-400 text-xs sm:text-sm">
@@ -206,7 +226,11 @@ export function ExperienceSection() {
                     setCurrentIndex(index);
                   }}
                   className={`w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full transition-colors ${
-                    index === currentIndex ? 'bg-green-500' : 'bg-green-500/20'
+                    index === currentIndex
+                      ? index === 0
+                        ? 'bg-yellow-500'
+                        : 'bg-green-500'
+                      : 'bg-green-500/20'
                   }`}
                 />
               ))}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -177,6 +177,42 @@ export function Terminal() {
     return contactContent.join('\n');
   };
 
+  const getExperienceData = () => {
+    const exp = [
+      '╭─ Work Experience ───────────────────────╮',
+      '│                                         ',
+      '│  MeDirect                               ',
+      '│  Junior Internal Red Team Security Eng. ',
+      '│  Jul 2025 – Present                     ',
+      '│  → Simulated cyber attacks to harden    ',
+      '│    bank defenses                        ',
+      '│                                         ',
+      '│  SG Solutions                           ',
+      '│  Junior Software Dev & Cybersecurity    ',
+      '│  Sales Assistant                        ',
+      '│  Jan 2025 – Jul 2025                    ',
+      '│  → Supported security product sales     ',
+      '│                                         ',
+      '│  Servizz.Gov                            ',
+      '│  IT Student Worker                      ',
+      '│  Jan 2024 – Dec 2024                    ',
+      '│  → Integrated Azure with Power BI       ',
+      '│                                         ',
+      '│  MITA                                   ',
+      '│  Cybersecurity SOC Tier 1 Intern        ',
+      '│  Aug 2024 – Aug 2024                    ',
+      '│  → Practiced threat hunting             ',
+      '│                                         ',
+      '│  TCTC                                   ',
+      '│  Summer Club Teacher & Mentor           ',
+      '│  Jun 2023 – Aug 2023                    ',
+      '│  → Taught Python & web basics           ',
+      '│                                         ',
+      '╰─────────────────────────────────────────╯',
+    ];
+    return exp.join('\n');
+  };
+
   const commands = useMemo(
     () =>
       createCommands({
@@ -190,6 +226,7 @@ export function Terminal() {
         getProjectsData,
         getSkillsData,
         getContactData,
+        getExperienceData,
       }),
     [navigate]
   );

--- a/src/components/terminalCommands.tsx
+++ b/src/components/terminalCommands.tsx
@@ -24,6 +24,7 @@ export interface CommandContext {
   getProjectsData: () => string;
   getSkillsData: () => string;
   getContactData: () => string;
+  getExperienceData: () => string;
 }
 
 export interface TerminalCommand {
@@ -44,6 +45,7 @@ export function createCommands(ctx: CommandContext): TerminalCommand[] {
     getProjectsData,
     getSkillsData,
     getContactData,
+    getExperienceData,
   } = ctx;
 
   return [
@@ -54,12 +56,13 @@ export function createCommands(ctx: CommandContext): TerminalCommand[] {
         const helpContent = [
           '╭─ Available Commands ───────────────────╮',
           '│                                       ',
-          '│  help     - Display this help message ',
-          '│  about    - Display portfolio info    ',
-          '│  projects - List project details      ',
-          '│  skills   - Display technical skills  ',
-          '│  contact  - Show contact information  ',
-          '│  ls       - List available sections   ',
+          '│  help       - Display this help message ',
+          '│  about      - Display portfolio info    ',
+          '│  experience - List work experience      ',
+          '│  projects   - List project details      ',
+          '│  skills     - Display technical skills  ',
+          '│  contact    - Show contact information  ',
+          '│  ls         - List available sections   ',
           '│  whoami   - Display current user      ',
           '│  version  - Terminal version          ',
           '│  social   - Social links              ',
@@ -96,6 +99,25 @@ export function createCommands(ctx: CommandContext): TerminalCommand[] {
             content: (
               <TypeWriter
                 text={`\n${getAboutData()}\n`}
+                onComplete={() => setIsTyping(false)}
+                speed="fast"
+              />
+            ),
+          },
+        ]);
+      },
+    },
+    {
+      name: 'experience',
+      description: 'List work experience',
+      action: () => {
+        setOutput(prev => [
+          ...prev,
+          {
+            type: 'success',
+            content: (
+              <TypeWriter
+                text={`\n${getExperienceData()}\n`}
                 onComplete={() => setIsTyping(false)}
                 speed="fast"
               />
@@ -171,7 +193,7 @@ export function createCommands(ctx: CommandContext): TerminalCommand[] {
             type: 'output',
             content: (
               <TypeWriter
-                text={'about\nprojects\nskills\ncontact'}
+                text={'about\nexperience\nprojects\nskills\ncontact'}
                 onComplete={() => setIsTyping(false)}
                 speed="fast"
               />


### PR DESCRIPTION
## Summary
- add MeDirect role and end SG Solutions tenure
- highlight current job in experience carousel
- expose experience history via terminal command

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892421437248322922850e3a528e4fc